### PR TITLE
feat(python/publish): allow specifying package dir in action

### DIFF
--- a/python/publish-package/action.yml
+++ b/python/publish-package/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: The url of the private package repository you want to upload to (if any).
     required: false
     default: NOT_SPECIFIED
+  dir:
+    description: The directory containing the package to publish
+    required: false
+    default: .
 
 runs:
   using: composite
@@ -15,6 +19,7 @@ runs:
     - name: Publish Python Package
       shell: bash
       run: |
+        cd ${{ inputs.dir }}
         if [[ "${{inputs.private-package-repo-url}}" != "NOT_SPECIFIED" ]]; then
           echo "Uploading to private repo"
           poetry config repositories.private ${{ inputs.private-package-repo-url }}


### PR DESCRIPTION
Created this for use in CAT while generating the CAT client library.

The CircleCI version of the code has this (private packages renamed to avoid leakage), which I did not include because it does not make sense that it would be necessary, but that doesn't mean it isn't:

```bash
            mv "sub_package" "../sub_package"
            cd "../sub_package"
            poetry publish --repository private --build
```