### PR TITLE
feat: allow empty username/password; fix text

### DIFF
--- a/python/install-and-configure-poetry/action.yml
+++ b/python/install-and-configure-poetry/action.yml
@@ -2,17 +2,17 @@ name: Install Poetry and Dependencies
 description: Installs/configures poetry and then installs the python dependencies.
 inputs:
   private-package-repo-url:
-    description: The url of the private package repository you want to add to poetry. You must also specify both `private-package-repo-username` and `private-package-repo-password`
+    description: The url of the private package repository you want to add to poetry. You must also specify `private-package-repo-username`
     required: false
-    default: NOT_SPECIFIED
+    default: ""
   private-package-repo-username:
     description: The username for the private package repository you want to add to poetry
     required: false
-    default: NOT_SPECIFIED
+    default: ""
   private-package-repo-password:
     description: The password for the private package repository you want to add to poetry
     required: false
-    default: NOT_SPECIFIED
+    default: ""
   exclude-dev-dependencies:
     description: If set to true, poetry install will be called with the --no-dev
     required: false
@@ -32,8 +32,13 @@ runs:
         python -m pip install --upgrade pip
         pip install poetry --upgrade
         poetry config virtualenvs.in-project true
-        if [[ "${{inputs.private-package-repo-url}}" != "NOT_SPECIFIED" ]]; then
-          poetry config repositories.private ${{ inputs.private-package-repo-url }}
+        if [ -n "${{inputs.private-package-repo-url}}" ]; then
+          if [ -z "${{inputs.private-package-repo-username}}" ]; then
+            echo "private-package-repo-username is required when private-package-repo-url is provided" 1>&2
+            exit 1
+          fi
+
+          poetry config repositories.private "${{ inputs.private-package-repo-url }}"
           poetry config http-basic.private "${{ inputs.private-package-repo-username }}" "${{ inputs.private-package-repo-password }}"
         fi
     - name: Install Python Dependencies

--- a/python/install-and-configure-poetry/action.yml
+++ b/python/install-and-configure-poetry/action.yml
@@ -6,11 +6,11 @@ inputs:
     required: false
     default: NOT_SPECIFIED
   private-package-repo-username:
-    description: The url of the private package repository you want to add to poetry
+    description: The username for the private package repository you want to add to poetry
     required: false
     default: NOT_SPECIFIED
   private-package-repo-password:
-    description: The url of the private package repository you want to add to poetry
+    description: The password for the private package repository you want to add to poetry
     required: false
     default: NOT_SPECIFIED
   exclude-dev-dependencies:
@@ -34,7 +34,7 @@ runs:
         poetry config virtualenvs.in-project true
         if [[ "${{inputs.private-package-repo-url}}" != "NOT_SPECIFIED" ]]; then
           poetry config repositories.private ${{ inputs.private-package-repo-url }}
-          poetry config http-basic.private ${{ inputs.private-package-repo-username }} ${{ inputs.private-package-repo-password }}
+          poetry config http-basic.private "${{ inputs.private-package-repo-username }}" "${{ inputs.private-package-repo-password }}"
         fi
     - name: Install Python Dependencies
       shell: bash


### PR DESCRIPTION
I believe the added quotation marks are necessary to allow an empty password with Gemfury. I also fixed the description text for the username/password inputs, which were copied from the URL input.