### PR TITLE
Run Poetry in a subdir

### DIFF
--- a/python/install-and-configure-poetry/action.yml
+++ b/python/install-and-configure-poetry/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: Extras to include when installing this package
     required: false
     default: NOT_SPECIFIED
+  working-directory:
+    description: The working directory where this action should run. Defaults to the root of the git repository.
+    required: false
+    default: "."
   
 
 runs:
@@ -28,6 +32,7 @@ runs:
   steps:
     - name: Install and Configure Poetry
       shell: bash
+      working-directory: "${{inputs.working-directory}}"
       run: |
         python -m pip install --upgrade pip
         pip install poetry --upgrade
@@ -43,6 +48,7 @@ runs:
         fi
     - name: Install Python Dependencies
       shell: bash
+      working-directory: "${{inputs.working-directory}}"
       run: |
         COMMAND="poetry install"
         if [[ "${{inputs.exclude-dev-dependencies}}" != "false" ]]; then


### PR DESCRIPTION
This adds a `working-directory` input to the poetry action, for when `pyproject.toml` is not in the root of the repo.