### PR TITLE
Fix: Temperory add flag to ignore warning in legacy service

### DIFF
--- a/python/run-checks/action.yml
+++ b/python/run-checks/action.yml
@@ -65,7 +65,7 @@ runs:
       # 80876: (Temporary) ignore issue
       # 73725: (Temporary) ignore issue
       # 68094: (Temporary) ignore issue
-      run: poetry export -f requirements.txt | poetry run safety check --bare --stdin -i 42194 -i 42050 -i 51668 -i 52983 -i 53310 -i 53332 -i 65213 -i 64930 -i 65293 -i 71199 -i 70612 -i 70626 -i 71083 -i 68094 -i 71594 -i 70624 -i 72731 -i 76903 -i 79193
+      run: poetry export -f requirements.txt | poetry run safety check --bare --stdin -i 42194 -i 42050 -i 51668 -i 52983 -i 53310 -i 53332 -i 65213 -i 64930 -i 65293 -i 71199 -i 70612 -i 70626 -i 71083 -i 68094 -i 71594 -i 70624 -i 72731 -i 76903 -i 79193 -i 82332 -i 82331 -i 82196
 
     - name: Run mypy
       shell: bash


### PR DESCRIPTION
Fix/legacy urlib werkzeug warning flag